### PR TITLE
Fix markdown link syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,6 @@ This is a tiny package to parse `.xliff` files.
 It is currently used in the following two projects:
 
 * In [Firefox Focus](https://github.com/mozilla-mobile/focus) to import strings from the Mozilla L10N Repository into the Focus Xcode project.
-* In [XLIFF Tool](https://github.com/st3fan/xlifftool), a generic XLIFF tool that will hopefully replace a number of specialized scripts that we use for [https://github.com/mozilla-mobile/firefox-ios](Firefox for iOS) and [https://github.com/mozilla-mobile/focus](Firefox Focus for iOS).
+* In [XLIFF Tool](https://github.com/st3fan/xlifftool), a generic XLIFF tool that will hopefully replace a number of specialized scripts that we use for [Firefox for iOS](https://github.com/mozilla-mobile/firefox-ios) and [Firefox Focus for iOS](https://github.com/mozilla-mobile/focus).
 
 > Please [file a bug](https://github.com/st3fan/xliff/issues/new) if you have some specific wish or requirement.


### PR DESCRIPTION
linked text first, anchor second